### PR TITLE
Add Travis-CI support and lint script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js: "6.11"
+
+before_script:
+  - npm install
+
+script:
+  - npm run lint
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # ark-api
 
+[![Build Status](https://travis-ci.org/ArkEcosystem/ark-api.svg?branch=master)](https://travis-ci.org/ArkEcosystem/ark-api)
+
 A Node.JS module which provides an wrapper for the [Ark API].
 
 ## Installation
 
 [![npm package](https://nodei.co/npm/ark-api.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/ark-api/)
+
 
 ## Table of contents
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Node.JS module which provides an wrapper for the Ark API.",
   "main": "src/index.js",
   "scripts": {
+    "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I've added Travis-CI support. Currently it will only run the lint. I also added the lint script, so you can just run `npm run lint`. Later on tests can be added as required.
This is helpful for reviewing pull request standards, as the code will have to follow the standards.

In order to setup Travis, any dev that is part of the ArkEcosystem organisation can register on travis-ci.org, and activate the repository on Travis. Any pull requests or commits after that will trigger a travis-ci build.